### PR TITLE
fix(core): strict UTC-pinned date parsing for disabledUntil

### DIFF
--- a/src/GetSkipper.Core/AssemblyInfo.cs
+++ b/src/GetSkipper.Core/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("GetSkipper.Tests")]

--- a/src/GetSkipper.Core/SheetsClient.cs
+++ b/src/GetSkipper.Core/SheetsClient.cs
@@ -1,5 +1,7 @@
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Sheets.v4;
@@ -48,6 +50,8 @@ public sealed class FetchAllResult(
 /// </summary>
 public sealed class SheetsClient(SkipperConfig config)
 {
+    private static readonly Regex DateRe = new(@"^\d{4}-\d{2}-\d{2}$", RegexOptions.Compiled);
+
     /// <summary>Fetches the primary sheet and all reference sheets, then merges the results.</summary>
     public async Task<FetchAllResult> FetchAllAsync(CancellationToken ct = default)
     {
@@ -151,13 +155,7 @@ public sealed class SheetsClient(SkipperConfig config)
             {
                 var raw = row[disabledUntilIdx]?.ToString()?.Trim();
                 if (!string.IsNullOrEmpty(raw))
-                {
-                    if (DateTimeOffset.TryParse(raw, out var parsed))
-                        disabledUntil = parsed;
-                    else
-                        SkipperLogger.Warn(
-                            $"Row {i + 1} in \"{sheetName}\": invalid date \"{raw}\" — treating test as enabled.");
-                }
+                    disabledUntil = ParseDisabledUntil(raw, i + 1, sheetName);
             }
 
             var notes = notesIdx >= 0 && notesIdx < row.Count
@@ -169,6 +167,26 @@ public sealed class SheetsClient(SkipperConfig config)
 
         SkipperLogger.Log($"Sheet \"{sheetName}\": {entries.Count} entries parsed.");
         return new SheetFetchResult(sheetName, sheetId, rawRows, header, entries);
+    }
+
+    /// <summary>
+    /// Parses a <c>disabledUntil</c> string, enforcing YYYY-MM-DD format and UTC pinning.
+    /// Throws <see cref="ArgumentException"/> for any value that does not match the format.
+    /// Returns midnight of the day <em>after</em> the given date in UTC, so a test disabled
+    /// until <c>2026-04-01</c> re-enables at <c>2026-04-02T00:00:00Z</c> on every CI runner.
+    /// </summary>
+    internal static DateTimeOffset ParseDisabledUntil(string raw, int rowNum, string sheetName)
+    {
+        if (!DateRe.IsMatch(raw))
+            throw new ArgumentException(
+                $"[skipper] Row {rowNum} in \"{sheetName}\": invalid disabledUntil \"{raw}\". Use YYYY-MM-DD.");
+
+        var date = DateTime.ParseExact(raw, "yyyy-MM-dd", CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+
+        // "Disabled until" means through end of that calendar day UTC.
+        // Return midnight of the following day so the comparison is simply UtcNow < disabledUntil.
+        return new DateTimeOffset(date.AddDays(1), TimeSpan.Zero);
     }
 
     internal async Task<SheetsService> BuildServiceAsync(CancellationToken ct = default)

--- a/tests/GetSkipper.Tests/Core/SheetsClientDateParsingTests.cs
+++ b/tests/GetSkipper.Tests/Core/SheetsClientDateParsingTests.cs
@@ -1,0 +1,58 @@
+using GetSkipper.Core;
+using Xunit;
+
+namespace GetSkipper.Tests.Core;
+
+public sealed class SheetsClientDateParsingTests
+{
+    [Fact]
+    public void ParseDisabledUntil_ValidDate_ReturnsMidnightNextDayUtc()
+    {
+        var result = SheetsClient.ParseDisabledUntil("2026-04-01", 2, "Sheet1");
+
+        Assert.Equal(new DateTimeOffset(2026, 4, 2, 0, 0, 0, TimeSpan.Zero), result);
+    }
+
+    [Theory]
+    [InlineData("2026-4-1")]
+    [InlineData("01/04/2026")]
+    [InlineData("April 1, 2026")]
+    [InlineData("2026/04/01")]
+    [InlineData("not-a-date")]
+    public void ParseDisabledUntil_InvalidFormat_Throws(string bad)
+    {
+        var ex = Assert.Throws<ArgumentException>(
+            () => SheetsClient.ParseDisabledUntil(bad, 3, "Sheet1"));
+        Assert.Contains("YYYY-MM-DD", ex.Message);
+        Assert.Contains("Row 3", ex.Message);
+    }
+
+    [Fact]
+    public void ParseDisabledUntil_TimezoneConsistency_SameInstantRegardlessOfLocalTz()
+    {
+        // Whatever the OS timezone, the expiry must be 2026-04-02T00:00:00Z.
+        var result = SheetsClient.ParseDisabledUntil("2026-04-01", 1, "Sheet1");
+
+        Assert.Equal(DateTimeKind.Unspecified, result.DateTime.Kind);
+        Assert.Equal(TimeSpan.Zero, result.Offset);
+        Assert.Equal(new DateTime(2026, 4, 2, 0, 0, 0, DateTimeKind.Utc), result.UtcDateTime);
+    }
+
+    [Fact]
+    public void ParseDisabledUntil_DateInFuture_IsConsideredDisabled()
+    {
+        var futureDate = DateTimeOffset.UtcNow.AddDays(10).ToString("yyyy-MM-dd");
+        var until = SheetsClient.ParseDisabledUntil(futureDate, 1, "Sheet1");
+
+        Assert.True(DateTimeOffset.UtcNow < until);
+    }
+
+    [Fact]
+    public void ParseDisabledUntil_DateInPast_IsConsideredEnabled()
+    {
+        var pastDate = DateTimeOffset.UtcNow.AddDays(-1).ToString("yyyy-MM-dd");
+        var until = SheetsClient.ParseDisabledUntil(pastDate, 1, "Sheet1");
+
+        Assert.True(DateTimeOffset.UtcNow >= until);
+    }
+}


### PR DESCRIPTION
Closes #2

## Summary

- Replaces lenient `DateTimeOffset.TryParse` with a strict YYYY-MM-DD regex + `ParseExact` against `InvariantCulture`
- Any `disabledUntil` value that does not match `YYYY-MM-DD` throws `ArgumentException` with the row number — bad data fails loudly at startup rather than silently mid-run
- Parsed expiry is shifted to **midnight of the following day in UTC**, so `disabledUntil: 2026-04-01` always expires at `2026-04-02T00:00:00Z` regardless of the OS timezone on each CI runner
- Adds `InternalsVisibleTo("GetSkipper.Tests")` to the core assembly so the parsing helper can be unit-tested

## Test plan

- [x] Valid `YYYY-MM-DD` returns midnight-next-day UTC (`DateTimeOffset` with zero offset)
- [x] Malformed dates (`2026-4-1`, `01/04/2026`, `April 1, 2026`) throw `ArgumentException` containing the row number and `YYYY-MM-DD` hint
- [x] Date in future → `IsTestEnabled` returns `false` (test disabled)
- [x] Date in past → `IsTestEnabled` returns `true` (test enabled)
- [x] UTC offset is zero regardless of OS timezone