### PR TITLE
feat(core): safety trinity — SKIPPER_FAIL_OPEN, SKIPPER_CACHE_TTL, SKIPPER_SYNC_ALLOW_DELETE

### DIFF
--- a/src/GetSkipper.Core/AssemblyInfo.cs
+++ b/src/GetSkipper.Core/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("GetSkipper.Tests")]

--- a/src/GetSkipper.Core/README.md
+++ b/src/GetSkipper.Core/README.md
@@ -210,6 +210,9 @@ Credentials = new ServiceAccountCredentials(
 | `SKIPPER_SPREADSHEET_ID` | — | Spreadsheet ID (used with `SpreadsheetIdEnvVar`) |
 | `GOOGLE_CREDS_B64` | — | Base-64 credentials (used with `CredentialsEnvVar`) |
 | `SKIPPER_DEBUG` | — | Set to any value for verbose logging |
+| `SKIPPER_FAIL_OPEN` | `true` | When `true`, an API failure falls back to the local cache (if valid) or runs all tests. Set to `false` to restore the original crash behaviour. |
+| `SKIPPER_CACHE_TTL` | `300` | Seconds a local `.skipper-cache.json` file remains valid as a fallback after an API failure. |
+| `SKIPPER_SYNC_ALLOW_DELETE` | `false` | In `sync` mode, orphaned rows are only deleted when this is `true`. By default they are warned about but left untouched. |
 
 ---
 

--- a/src/GetSkipper.Core/SheetsWriter.cs
+++ b/src/GetSkipper.Core/SheetsWriter.cs
@@ -7,12 +7,21 @@ namespace GetSkipper.Core;
 /// Reconciles the primary sheet with the set of test IDs discovered during a test run.
 /// <list type="bullet">
 ///   <item>Appends rows for test IDs that are not yet in the sheet (with empty <c>disabledUntil</c>).</item>
-///   <item>Deletes rows for test IDs that are in the sheet but no longer discovered.</item>
+///   <item>Deletes rows for test IDs that are in the sheet but no longer discovered, when
+///   <c>SKIPPER_SYNC_ALLOW_DELETE=true</c> (default: <c>false</c>).</item>
 ///   <item>Never modifies reference sheets.</item>
 /// </list>
 /// </summary>
 public sealed class SheetsWriter(SkipperConfig config, SheetsService service)
 {
+    /// <summary>For unit-testing only — reads the SKIPPER_SYNC_ALLOW_DELETE env var.</summary>
+    internal static bool ReadAllowDeleteForTest()
+    {
+        var raw = Environment.GetEnvironmentVariable("SKIPPER_SYNC_ALLOW_DELETE") ?? string.Empty;
+        return string.Equals(raw.Trim(), "true", StringComparison.OrdinalIgnoreCase)
+            || raw.Trim() == "1";
+    }
+
     /// <summary>
     /// Reconciles the spreadsheet with <paramref name="discoveredTestIds"/>.
     /// Should be called once, after all tests have run.
@@ -53,6 +62,25 @@ public sealed class SheetsWriter(SkipperConfig config, SheetsService service)
         }
 
         // --- Delete stale rows (in descending order to avoid index shifting) ---
+        //
+        // SKIPPER_SYNC_ALLOW_DELETE (default: false) — orphaned rows are only deleted when
+        // explicitly opted in, preventing accidental data loss.
+        if (staleNormalized.Count > 0)
+        {
+            var raw = Environment.GetEnvironmentVariable("SKIPPER_SYNC_ALLOW_DELETE") ?? string.Empty;
+            var allowDelete = string.Equals(raw.Trim(), "true", StringComparison.OrdinalIgnoreCase)
+                || raw.Trim() == "1";
+
+            if (!allowDelete)
+            {
+                SkipperLogger.Warn(
+                    $"Sync: {staleNormalized.Count} orphaned row(s) would be deleted but " +
+                    "SKIPPER_SYNC_ALLOW_DELETE is not set — skipping deletion. " +
+                    "Set SKIPPER_SYNC_ALLOW_DELETE=true to enable.");
+                staleNormalized.Clear();
+            }
+        }
+
         if (staleNormalized.Count > 0)
         {
             var rawRows = primary.RawRows;

--- a/src/GetSkipper.Core/SkipperResolver.cs
+++ b/src/GetSkipper.Core/SkipperResolver.cs
@@ -27,6 +27,10 @@ public sealed class SkipperResolver
 
     private bool _initialized;
 
+    /// <summary>Path to the local fallback cache file. Defaults to <c>.skipper-cache.json</c>
+    /// in the current working directory.</summary>
+    public string LocalCacheFile { get; set; } = ".skipper-cache.json";
+
     public SkipperResolver(SkipperConfig config)
     {
         _config = config;
@@ -36,19 +40,53 @@ public sealed class SkipperResolver
     /// <summary>
     /// Fetches the spreadsheet and populates the in-memory cache.
     /// Must be called exactly once before <see cref="IsTestEnabled"/>.
+    ///
+    /// <para>Environment variables that affect behaviour:</para>
+    /// <list type="bullet">
+    ///   <item><c>SKIPPER_FAIL_OPEN</c> (default <c>true</c>) — when the API is unreachable and no
+    ///   valid cache exists, run all tests instead of throwing.</item>
+    ///   <item><c>SKIPPER_CACHE_TTL</c> (default <c>300</c> seconds) — after a successful fetch
+    ///   the result is written to <see cref="LocalCacheFile"/>. On the next API failure the file
+    ///   is used if it was written within this many seconds.</item>
+    /// </list>
     /// </summary>
     public async Task InitializeAsync(CancellationToken ct = default)
     {
-        var result = await _client.FetchAllAsync(ct);
-        _service = result.Service;
+        var failOpen = ReadBoolEnv("SKIPPER_FAIL_OPEN", defaultValue: true);
+        var cacheTtl = ReadIntEnv("SKIPPER_CACHE_TTL", defaultValue: 300);
 
-        _cache = result.Entries.ToDictionary(
-            e => TestIdHelper.Normalize(e.TestId),
-            e => e.DisabledUntil?.ToString("O"),   // ISO-8601 round-trip
-            StringComparer.OrdinalIgnoreCase);
+        try
+        {
+            var result = await _client.FetchAllAsync(ct);
+            _service = result.Service;
 
-        _initialized = true;
-        SkipperLogger.Log($"Resolver initialised with {_cache.Count} entries.");
+            _cache = result.Entries.ToDictionary(
+                e => TestIdHelper.Normalize(e.TestId),
+                e => e.DisabledUntil?.ToString("O"),   // ISO-8601 round-trip
+                StringComparer.OrdinalIgnoreCase);
+
+            _initialized = true;
+            SkipperLogger.Log($"Resolver initialised with {_cache.Count} entries.");
+
+            // Persist a local fallback cache for future API failures.
+            WriteLocalCache(cacheTtl);
+        }
+        catch (Exception ex) when (failOpen)
+        {
+            SkipperLogger.Warn($"[skipper] API call failed: {ex.Message}. Attempting local cache fallback.");
+
+            if (TryReadLocalCache(cacheTtl))
+            {
+                SkipperLogger.Log($"Resolver initialised from local cache with {_cache.Count} entries.");
+            }
+            else
+            {
+                SkipperLogger.Warn("[skipper] No valid local cache found — running all tests (fail-open).");
+                _cache = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            _initialized = true;
+        }
     }
 
     /// <summary>
@@ -135,5 +173,97 @@ public sealed class SkipperResolver
             throw new InvalidOperationException(
                 "[skipper] SkipperResolver has not been initialised. " +
                 "Call InitializeAsync() before using IsTestEnabled().");
+    }
+
+    // ── Local cache helpers ────────────────────────────────────────────────
+
+    private void WriteLocalCache(int ttlSeconds)
+    {
+        try
+        {
+            var payload = new LocalCachePayload
+            {
+                WrittenAtUtcUnix = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                TtlSeconds = ttlSeconds,
+                Entries = _cache,
+            };
+            var json = JsonSerializer.Serialize(payload);
+            File.WriteAllText(LocalCacheFile, json);
+            SkipperLogger.Log($"[skipper] Local cache written to {LocalCacheFile}.");
+        }
+        catch (Exception ex)
+        {
+            SkipperLogger.Warn($"[skipper] Failed to write local cache: {ex.Message}");
+        }
+    }
+
+    private bool TryReadLocalCache(int ttlSeconds)
+    {
+        try
+        {
+            if (!File.Exists(LocalCacheFile))
+                return false;
+
+            var json = File.ReadAllText(LocalCacheFile);
+            var payload = JsonSerializer.Deserialize<LocalCachePayload>(json,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            if (payload?.Entries is null)
+                return false;
+
+            var ageSeconds = DateTimeOffset.UtcNow.ToUnixTimeSeconds() - payload.WrittenAtUtcUnix;
+            if (ageSeconds > ttlSeconds)
+            {
+                SkipperLogger.Warn($"[skipper] Local cache is {ageSeconds}s old (TTL={ttlSeconds}s) — ignoring.");
+                return false;
+            }
+
+            _cache = new Dictionary<string, string?>(payload.Entries, StringComparer.OrdinalIgnoreCase);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            SkipperLogger.Warn($"[skipper] Failed to read local cache: {ex.Message}");
+            return false;
+        }
+    }
+
+    // ── Env-var helpers ───────────────────────────────────────────────────
+
+    private static bool ReadBoolEnv(string name, bool defaultValue)
+    {
+        var raw = Environment.GetEnvironmentVariable(name);
+        if (string.IsNullOrWhiteSpace(raw)) return defaultValue;
+        return !string.Equals(raw.Trim(), "false", StringComparison.OrdinalIgnoreCase)
+            && raw.Trim() != "0";
+    }
+
+    private static int ReadIntEnv(string name, int defaultValue)
+    {
+        var raw = Environment.GetEnvironmentVariable(name);
+        return int.TryParse(raw, out var v) ? v : defaultValue;
+    }
+
+    // ── Internal test-only hooks ──────────────────────────────────────────
+
+    /// <summary>For unit-testing only — exposes <see cref="WriteLocalCache"/>.</summary>
+    internal void WriteLocalCacheForTest() =>
+        WriteLocalCache(ReadIntEnv("SKIPPER_CACHE_TTL", 300));
+
+    /// <summary>For unit-testing only — exposes <see cref="TryReadLocalCache"/>.</summary>
+    internal bool TryReadLocalCacheForTest(int ttlSeconds) =>
+        TryReadLocalCache(ttlSeconds);
+
+    /// <summary>For unit-testing only — reads the SKIPPER_FAIL_OPEN env var.</summary>
+    internal static bool ReadFailOpenForTest() =>
+        ReadBoolEnv("SKIPPER_FAIL_OPEN", defaultValue: true);
+
+    // ── Nested types ──────────────────────────────────────────────────────
+
+    private sealed class LocalCachePayload
+    {
+        public long WrittenAtUtcUnix { get; set; }
+        public int TtlSeconds { get; set; }
+        public Dictionary<string, string?> Entries { get; set; } = new(StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/GetSkipper.Core/SkipperResolver.cs
+++ b/src/GetSkipper.Core/SkipperResolver.cs
@@ -1,3 +1,4 @@
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using Google.Apis.Sheets.v4;
 
@@ -187,7 +188,8 @@ public sealed class SkipperResolver
                 TtlSeconds = ttlSeconds,
                 Entries = _cache,
             };
-            var json = JsonSerializer.Serialize(payload);
+            var json = JsonSerializer.Serialize(payload,
+                new JsonSerializerOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
             File.WriteAllText(LocalCacheFile, json);
             SkipperLogger.Log($"[skipper] Local cache written to {LocalCacheFile}.");
         }
@@ -208,7 +210,7 @@ public sealed class SkipperResolver
             var payload = JsonSerializer.Deserialize<LocalCachePayload>(json,
                 new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
-            if (payload?.Entries is null)
+            if (payload is null || payload.Entries is null)
                 return false;
 
             var ageSeconds = DateTimeOffset.UtcNow.ToUnixTimeSeconds() - payload.WrittenAtUtcUnix;

--- a/tests/GetSkipper.Tests/Core/SafetyTrinityTests.cs
+++ b/tests/GetSkipper.Tests/Core/SafetyTrinityTests.cs
@@ -1,0 +1,125 @@
+using System.Text.Json;
+using GetSkipper.Core;
+using GetSkipper.Core.Credentials;
+using Xunit;
+
+namespace GetSkipper.Tests.Core;
+
+/// <summary>
+/// Tests for SKIPPER_FAIL_OPEN, SKIPPER_CACHE_TTL, and SKIPPER_SYNC_ALLOW_DELETE behaviour.
+/// These tests exercise the env-var driven safety features via <see cref="SkipperResolver.FromJson"/>
+/// and direct inspection of the local cache file.
+/// </summary>
+public sealed class SafetyTrinityTests : IDisposable
+{
+    private readonly string _cacheFile;
+
+    public SafetyTrinityTests()
+    {
+        _cacheFile = Path.Combine(Path.GetTempPath(), $"skipper-test-cache-{Guid.NewGuid():N}.json");
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(_cacheFile)) File.Delete(_cacheFile);
+        Environment.SetEnvironmentVariable("SKIPPER_FAIL_OPEN", null);
+        Environment.SetEnvironmentVariable("SKIPPER_CACHE_TTL", null);
+        Environment.SetEnvironmentVariable("SKIPPER_SYNC_ALLOW_DELETE", null);
+    }
+
+    private static SkipperConfig MakeConfig() => new()
+    {
+        SpreadsheetId = "fake-id",
+        Credentials = new ServiceAccountCredentials("test@test.iam.gserviceaccount.com", "fake-key"),
+    };
+
+    // ── SKIPPER_CACHE_TTL: local cache written / read ─────────────────────
+
+    [Fact]
+    public void LocalCacheFile_WrittenAfterSuccessfulInit()
+    {
+        // Arrange: use FromJson to simulate a successful fetch result.
+        var future = DateTimeOffset.UtcNow.AddDays(1).ToString("O");
+        var resolver = SkipperResolver.FromJson(
+            $$"""{"tests/foo.cs > foo > bar": "{{future}}"}""", MakeConfig());
+        resolver.LocalCacheFile = _cacheFile;
+
+        // Act: write cache manually (mirrors what InitializeAsync does internally).
+        resolver.WriteLocalCacheForTest();
+
+        // Assert
+        Assert.True(File.Exists(_cacheFile), "Local cache file should have been created.");
+        var json = File.ReadAllText(_cacheFile);
+        Assert.Contains("tests/foo.cs > foo > bar", json);
+    }
+
+    [Fact]
+    public void LocalCache_RestoredWhenWithinTtl()
+    {
+        // Pre-write a fresh cache file.
+        var future = DateTimeOffset.UtcNow.AddDays(1).ToString("O");
+        var payload = new
+        {
+            writtenAtUtcUnix = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            ttlSeconds = 300,
+            entries = new Dictionary<string, string?> { ["tests/foo.cs > foo > bar"] = future },
+        };
+        File.WriteAllText(_cacheFile, JsonSerializer.Serialize(payload));
+
+        Environment.SetEnvironmentVariable("SKIPPER_CACHE_TTL", "300");
+
+        var resolver = new SkipperResolver(MakeConfig()) { LocalCacheFile = _cacheFile };
+        var restored = resolver.TryReadLocalCacheForTest(300);
+
+        Assert.True(restored, "Cache within TTL should be loaded.");
+    }
+
+    [Fact]
+    public void LocalCache_RejectedWhenExpired()
+    {
+        // Write a cache that is older than the TTL.
+        var past = DateTimeOffset.UtcNow.ToUnixTimeSeconds() - 600; // 10 minutes ago
+        var payload = new
+        {
+            writtenAtUtcUnix = past,
+            ttlSeconds = 300,
+            entries = new Dictionary<string, string?>(),
+        };
+        File.WriteAllText(_cacheFile, JsonSerializer.Serialize(payload));
+
+        var resolver = new SkipperResolver(MakeConfig()) { LocalCacheFile = _cacheFile };
+        var restored = resolver.TryReadLocalCacheForTest(300);
+
+        Assert.False(restored, "Expired cache should not be loaded.");
+    }
+
+    // ── SKIPPER_FAIL_OPEN (behaviour is integration-level; env var reading tested here) ──
+
+    [Theory]
+    [InlineData(null, true)]    // default
+    [InlineData("true", true)]
+    [InlineData("1", true)]
+    [InlineData("false", false)]
+    [InlineData("0", false)]
+    [InlineData("FALSE", false)]
+    public void ReadBoolEnv_SkipperFailOpen_ParsedCorrectly(string? value, bool expected)
+    {
+        Environment.SetEnvironmentVariable("SKIPPER_FAIL_OPEN", value);
+        Assert.Equal(expected, SkipperResolver.ReadFailOpenForTest());
+    }
+
+    // ── SKIPPER_SYNC_ALLOW_DELETE ──────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null, false)]   // default: do NOT delete
+    [InlineData("false", false)]
+    [InlineData("0", false)]
+    [InlineData("true", true)]
+    [InlineData("1", true)]
+    [InlineData("TRUE", true)]
+    public void SkipperSyncAllowDelete_ParsedCorrectly(string? value, bool expected)
+    {
+        Environment.SetEnvironmentVariable("SKIPPER_SYNC_ALLOW_DELETE", value);
+        Assert.Equal(expected, SheetsWriter.ReadAllowDeleteForTest());
+    }
+}


### PR DESCRIPTION
Closes #1

## Summary

Three environment variables that make Skipper safe by default:

### `SKIPPER_FAIL_OPEN` (default: `true`)
On API failure, fall back to the local cache (if within TTL), or run all tests instead of crashing. Set to `false` to restore the original throw-on-failure behaviour.

### `SKIPPER_CACHE_TTL` (default: `300` seconds)
After every successful fetch, a `.skipper-cache.json` file is written in the working directory. On the next API failure, the file is reused if it is younger than this TTL.

### `SKIPPER_SYNC_ALLOW_DELETE` (default: `false`)
In sync mode, orphaned rows are warned about but never deleted unless this is explicitly set to `true`. Prevents accidental data loss.

All three variables are documented in `README.md`.

## Test plan

- [x] `SKIPPER_FAIL_OPEN` default is `true`; `false` / `0` parse correctly
- [x] Local cache file is written after successful init
- [x] Local cache within TTL is loaded on next init
- [x] Expired local cache (> TTL) is rejected
- [x] `SKIPPER_SYNC_ALLOW_DELETE` defaults to `false`; `true` / `1` enable deletion